### PR TITLE
feat: add orca-slicer-api container image

### DIFF
--- a/containers/orca-slicer-api/README.md
+++ b/containers/orca-slicer-api/README.md
@@ -1,0 +1,42 @@
+# orca-slicer-api Container Image
+
+Container image for [orca-slicer-api](https://github.com/maziggy/orca-slicer-api/tree/bambuddy/profile-resolver), an HTTP wrapper around the OrcaSlicer CLI built from the `maziggy` fork's `bambuddy/profile-resolver` branch. This fork adds profile-inheritance fixes required by [BambuBuddy](https://github.com/BambuBuddy/BambuBuddy).
+
+## Why a custom image?
+
+The upstream `orca-slicer-api` project does not publish images for the `maziggy/bambuddy/profile-resolver` fork, which contains profile-resolution patches that BambuBuddy depends on. This image builds directly from that fork's branch so BambuBuddy can use a stable, versioned image from GHCR.
+
+## Usage (Docker)
+
+```bash
+docker pull ghcr.io/mirceanton/orca-slicer-api:latest
+```
+
+```bash
+docker run --rm -p 8080:8080 ghcr.io/mirceanton/orca-slicer-api:latest
+```
+
+## Usage (Kubernetes)
+
+```yaml
+controllers:
+  orca-slicer-api:
+    containers:
+      orca-slicer-api:
+        image:
+          repository: ghcr.io/mirceanton/orca-slicer-api
+          tag: latest #! replace with a specific version
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            memory: 512Mi
+
+service:
+  orca-slicer-api:
+    ports:
+      http:
+        port: 8080
+```

--- a/containers/orca-slicer-api/docker-bake.hcl
+++ b/containers/orca-slicer-api/docker-bake.hcl
@@ -1,0 +1,37 @@
+DATE = formatdate( "YYYY.MM.DD", timestamp() )
+variable "GIT_SHA" {}
+variable "VERSION" {
+    # renovate: datasource=github-releases depName=SoftFever/OrcaSlicer extractVersion=^v(?P<version>.+)$
+    default = "2.3.2"
+}
+
+target "default" {
+    context    = "https://github.com/maziggy/orca-slicer-api.git#bambuddy/profile-resolver"
+    dockerfile = "Dockerfile"
+    no-cache   = true
+    platforms  = ["linux/amd64"]
+    args       = { ORCA_VERSION = VERSION }
+
+    tags = [
+        "ghcr.io/mirceanton/orca-slicer-api:latest",
+        "ghcr.io/mirceanton/orca-slicer-api:sha-${GIT_SHA}",
+        "ghcr.io/mirceanton/orca-slicer-api:date-${DATE}",
+        "ghcr.io/mirceanton/orca-slicer-api:${VERSION}",
+        can(regex("^[0-9]+\\.[0-9]+\\.[0-9]+", VERSION)) ? "ghcr.io/mirceanton/orca-slicer-api:${regex("^([0-9]+\\.[0-9]+)", VERSION)[0]}" : "",
+        can(regex("^[0-9]+\\.[0-9]+\\.[0-9]+", VERSION)) ? "ghcr.io/mirceanton/orca-slicer-api:${regex("^([0-9]+)", VERSION)[0]}" : ""
+    ]
+
+    labels = {
+        "org.opencontainers.image.vendor"      = "Mircea-Pavel Anton"
+        "org.opencontainers.image.source"      = "https://github.com/mirceanton/container-images"
+        "org.opencontainers.image.created"     = "${DATE}"
+        "org.opencontainers.image.revision"    = "${GIT_SHA}"
+        "org.opencontainers.image.licenses"    = "MIT"
+
+        "org.opencontainers.image.title"       = "orca-slicer-api"
+        "org.opencontainers.image.authors"     = "maziggy"
+        "org.opencontainers.image.description" = "OrcaSlicer CLI HTTP wrapper with BambuBuddy profile resolution patches"
+        "org.opencontainers.image.url"         = "https://github.com/maziggy/orca-slicer-api/tree/bambuddy/profile-resolver"
+        "org.opencontainers.image.version"     = "${VERSION}"
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `containers/orca-slicer-api/docker-bake.hcl` — builds from the `maziggy/orca-slicer-api` fork's `bambuddy/profile-resolver` branch, which carries profile-inheritance fixes that upstream OrcaSlicer lacks
- Publishes to `ghcr.io/mirceanton/orca-slicer-api` with the standard tag set (`latest`, `sha-*`, `date-*`, semver aliases)
- Adds `containers/orca-slicer-api/README.md` documenting the image and the reason for the custom build
- Version tracking wired up via Renovate against `SoftFever/OrcaSlicer` GitHub releases

## Why a custom image?

BambuBuddy supports an optional slicer backend. The `maziggy` fork adds profile-resolution fixes required by BambuBuddy that have not been merged upstream, and no pre-built images exist for that fork's branch.
