### PR TITLE
feat: add bambu-studio-api container image

### DIFF
--- a/containers/bambu-studio-api/README.md
+++ b/containers/bambu-studio-api/README.md
@@ -1,0 +1,43 @@
+# bambu-studio-api Container Image
+
+Container image for [bambu-studio-api](https://github.com/maziggy/orca-slicer-api/tree/bambuddy/profile-resolver), a headless Bambu Studio CLI wrapped in an HTTP API built from the `maziggy` fork's `bambuddy/profile-resolver` branch. This fork adds profile-inheritance fixes required by [BambuBuddy](https://github.com/BambuBuddy/BambuBuddy).
+
+## Why a custom image?
+
+The upstream `orca-slicer-api` project does not publish images for the `maziggy/bambuddy/profile-resolver` fork, and provides no pre-built image for the Bambu Studio variant at all. This image builds directly from that fork's `Dockerfile.bambu-studio` so BambuBuddy can use a stable, versioned image from GHCR.
+
+## Usage (Docker)
+
+```bash
+docker pull ghcr.io/mirceanton/bambu-studio-api:latest
+```
+
+```bash
+docker run --rm -p 3001:3000 ghcr.io/mirceanton/bambu-studio-api:latest
+```
+
+## Usage (Kubernetes)
+
+```yaml
+controllers:
+  bambu-studio-api:
+    containers:
+      bambu-studio-api:
+        image:
+          repository: ghcr.io/mirceanton/bambu-studio-api
+          tag: latest #! replace with a specific version
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            memory: 1Gi
+
+service:
+  bambu-studio-api:
+    ports:
+      http:
+        port: 3001
+        targetPort: 3000
+```

--- a/containers/bambu-studio-api/docker-bake.hcl
+++ b/containers/bambu-studio-api/docker-bake.hcl
@@ -1,0 +1,35 @@
+DATE = formatdate( "YYYY.MM.DD", timestamp() )
+variable "GIT_SHA" {}
+variable "VERSION" {
+    # renovate: datasource=github-releases depName=bambulab/BambuStudio extractVersion=^v(?P<version>.+)$ versioning=loose
+    default = "02.06.00.51"
+}
+
+target "default" {
+    context    = "https://github.com/maziggy/orca-slicer-api.git#bambuddy/profile-resolver"
+    dockerfile = "Dockerfile.bambu-studio"
+    no-cache   = true
+    platforms  = ["linux/amd64"]
+    args       = { BAMBU_VERSION = VERSION }
+
+    tags = [
+        "ghcr.io/mirceanton/bambu-studio-api:latest",
+        "ghcr.io/mirceanton/bambu-studio-api:sha-${GIT_SHA}",
+        "ghcr.io/mirceanton/bambu-studio-api:date-${DATE}",
+        "ghcr.io/mirceanton/bambu-studio-api:${VERSION}",
+    ]
+
+    labels = {
+        "org.opencontainers.image.vendor"      = "Mircea-Pavel Anton"
+        "org.opencontainers.image.source"      = "https://github.com/mirceanton/container-images"
+        "org.opencontainers.image.created"     = "${DATE}"
+        "org.opencontainers.image.revision"    = "${GIT_SHA}"
+        "org.opencontainers.image.licenses"    = "MIT"
+
+        "org.opencontainers.image.title"       = "bambu-studio-api"
+        "org.opencontainers.image.authors"     = "maziggy"
+        "org.opencontainers.image.description" = "Bambu Studio CLI HTTP wrapper with BambuBuddy profile resolution patches"
+        "org.opencontainers.image.url"         = "https://github.com/maziggy/orca-slicer-api/tree/bambuddy/profile-resolver"
+        "org.opencontainers.image.version"     = "${VERSION}"
+    }
+}


### PR DESCRIPTION
Builds the Bambu Studio CLI HTTP wrapper from maziggy/orca-slicer-api's
Dockerfile.bambu-studio (bambuddy/profile-resolver branch) — the same
upstream used for orca-slicer-api, just the Bambu Studio variant.
No pre-built image exists upstream, so this publishes a versioned image
to GHCR for use as a BambuBuddy sidecar.
