### PR TITLE
feat(steam-sunshine): add nvtop, mangohud and network diagnostic tools

### DIFF
--- a/containers/steam-sunshine/Dockerfile
+++ b/containers/steam-sunshine/Dockerfile
@@ -83,6 +83,7 @@ RUN dpkg --add-architecture i386 && \
         gzip \
         nano \
         htop \
+        nvtop \
         # Process manager
         supervisor \
         # Audio (PipeWire/ALSA compat libs; the PipeWire stack itself is added below)

--- a/containers/steam-sunshine/Dockerfile
+++ b/containers/steam-sunshine/Dockerfile
@@ -84,6 +84,10 @@ RUN dpkg --add-architecture i386 && \
         nano \
         htop \
         nvtop \
+        # Network diagnostics (bandwidth / latency / packet loss -- stream quality)
+        iperf3 \
+        mtr-tiny \
+        iftop \
         # Process manager
         supervisor \
         # Audio (PipeWire/ALSA compat libs; the PipeWire stack itself is added below)
@@ -98,6 +102,9 @@ RUN dpkg --add-architecture i386 && \
         # GL / Vulkan diagnostics + loader
         mesa-utils \
         vulkan-tools \
+        # In-game FPS/frametime/GPU/CPU overlay (Proton: `mangohud %command%`).
+        # amd64-only in Ubuntu; the overlay is unavailable for 32-bit titles.
+        mangohud \
         libvulkan1 \
         libvulkan1:i386 \
         # NVIDIA driver installer dependencies (driver userspace is installed at runtime by entrypoint.sh)


### PR DESCRIPTION
## Summary

Adds performance-analysis / troubleshooting tooling to the `steam-sunshine` image, targeting the things that most affect a Sunshine/Moonlight session — GPU/render performance and network quality:

- **`nvtop`** — htop-style NVIDIA GPU process/utilization monitor (Closes #55).
- **`mangohud`** — in-game FPS/frametime/GPU/CPU/temp overlay. For Steam/Proton, use the `mangohud %command%` launch option (or `MANGOHUD=1`).
- **`iperf3`** — bandwidth measurement between host and client.
- **`mtr-tiny`** — continuous latency + packet-loss along the network path (catches the Wi-Fi/router issues behind stream artifacts).
- **`iftop`** — live per-interface throughput.

### Note on MangoHud / 32-bit titles
Ubuntu 24.04 packages MangoHud as amd64-only (`mangohud:i386` does not exist), so the overlay works for 64-bit Proton/native titles but is unavailable for 32-bit games. Documented inline in the Dockerfile.

## Testing

- `hadolint` passes (the 5 warnings are pre-existing).
- Built locally with `docker buildx bake` — build succeeds.
- Verified binaries in the image: `/usr/bin/nvtop` (v3.0.2), `/usr/bin/mangohud`, `/usr/bin/iperf3` (iperf 3.16), `/usr/bin/mtr`, `/usr/sbin/iftop`.

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)