### PR TITLE
feat(steam-sunshine): add system-wide MangoHud overlay preset

### DIFF
--- a/containers/steam-sunshine/Dockerfile
+++ b/containers/steam-sunshine/Dockerfile
@@ -247,6 +247,11 @@ COPY files/set-wallpaper.sh    /usr/local/bin/set-wallpaper.sh
 COPY files/set-wallpaper.desktop /etc/xdg/autostart/set-wallpaper.desktop
 RUN chmod 0755 /usr/local/bin/set-wallpaper.sh
 
+# System-wide MangoHud overlay preset (applies to every game; per-user config in
+# ~/.config/MangoHud/MangoHud.conf overrides it). Enable per game with the Proton
+# launch option `mangohud %command%`; toggle in-game with Right Shift + F12.
+COPY files/MangoHud.conf /etc/MangoHud.conf
+
 # -------------------------------------------------------------------------------
 # PipeWire + WirePlumber (upstream PPA) -- Sunshine captures audio from this stack.
 # -------------------------------------------------------------------------------

--- a/containers/steam-sunshine/files/MangoHud.conf
+++ b/containers/steam-sunshine/files/MangoHud.conf
@@ -1,0 +1,54 @@
+################################################################################
+# System-wide MangoHud default preset for the steam-sunshine image.
+#
+# This lives at /etc/MangoHud.conf so it applies to every game out of the box,
+# regardless of the (persistent) home volume. Per-user overrides take priority
+# and go in ~/.config/MangoHud/MangoHud.conf.
+#
+# Enable the overlay per game via the Steam/Proton launch option
+# `mangohud %command%` (or globally with the MANGOHUD=1 env var).
+# Toggle it in-game with Right Shift + F12.
+#
+# Full option reference: https://github.com/flightlessmango/MangoHud
+################################################################################
+
+### Layout & appearance --------------------------------------------------------
+legacy_layout=false
+position=top-left
+table_columns=3
+font_size=20
+background_alpha=0.4
+alpha=0.9
+round_corners=8
+toggle_hud=Shift_R+F12
+
+### Frame rate / pacing ---------------------------------------------------------
+fps
+frametime
+frame_timing
+histogram
+fps_color_change
+
+### GPU (NVIDIA via NVML) -------------------------------------------------------
+gpu_stats
+gpu_load_change
+gpu_temp
+gpu_core_clock
+gpu_mem_clock
+gpu_power
+vram
+
+### CPU -------------------------------------------------------------------------
+cpu_stats
+cpu_load_change
+cpu_temp
+cpu_power
+
+### Memory ----------------------------------------------------------------------
+ram
+
+### Context (small, shown once) -------------------------------------------------
+gpu_name
+engine_version
+vulkan_driver
+resolution


### PR DESCRIPTION
## Summary

Ships a sensible system-wide MangoHud default at `/etc/MangoHud.conf`, so the overlay shows useful stats out of the box once enabled — no per-user setup required.

The preset includes:
- **Frame pacing:** FPS, frametime, frametime histogram graph, FPS color thresholds
- **GPU (NVIDIA/NVML):** load, temp, core/mem clocks, power, VRAM
- **CPU:** load, temp, power
- **Memory:** RAM
- **Context:** GPU name, engine version, Vulkan driver, resolution
- Top-left position, `Right Shift + F12` toggle

### Notes
- `/etc/MangoHud.conf` is system-wide and unaffected by the persistent home volume. Per-user config in `~/.config/MangoHud/MangoHud.conf` still takes priority.
- Enable per game via the Steam/Proton launch option `mangohud %command%` (or globally with `MANGOHUD=1`).

## Testing

- `hadolint` passes (the 5 warnings are pre-existing).
- Built locally with `docker buildx bake` — build succeeds.
- Verified the file lands at `/etc/MangoHud.conf` in the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)