### PR TITLE
feat(load-tester): add REST API image for simulating CPU/RAM load

### DIFF
--- a/containers/load-tester/Dockerfile
+++ b/containers/load-tester/Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.13-alpine
+
+WORKDIR /app
+
+# hadolint ignore=DL3018
+RUN apk add --no-cache gcc musl-dev linux-headers
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app.py .
+
+ENV PORT=8080
+ENV CPU_PERCENT=80
+ENV RAM_PERCENT=0
+ENV BURN_DURATION=30
+
+EXPOSE 8080
+
+ENTRYPOINT ["gunicorn", "--bind", "0.0.0.0:8080", "--workers", "1", "--threads", "8", "app:app"]

--- a/containers/load-tester/app.py
+++ b/containers/load-tester/app.py
@@ -1,0 +1,91 @@
+import os
+import time
+import threading
+import multiprocessing
+import ctypes
+import math
+from flask import Flask, jsonify
+
+app = Flask(__name__)
+
+CPU_PERCENT = int(os.environ.get("CPU_PERCENT", 80))
+RAM_PERCENT = int(os.environ.get("RAM_PERCENT", 0))
+DURATION = int(os.environ.get("BURN_DURATION", 30))
+
+_burn_lock = threading.Lock()
+_burn_active = False
+
+
+def _cpu_worker(stop_event, target_percent, duration):
+    deadline = time.time() + duration
+    cycle = 0.1
+    on_time = cycle * (target_percent / 100.0)
+    off_time = cycle - on_time
+    while not stop_event.is_set() and time.time() < deadline:
+        start = time.time()
+        while time.time() - start < on_time:
+            math.factorial(5000)
+        time.sleep(off_time)
+
+
+def _ram_worker(stop_event, target_percent, duration):
+    total = os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
+    size = int(total * target_percent / 100)
+    buf = ctypes.create_string_buffer(size)
+    ctypes.memset(buf, 0, size)
+    stop_event.wait(timeout=duration)
+
+
+def _run_burn(cpu_pct, ram_pct, duration):
+    global _burn_active
+    stop = threading.Event()
+    threads = []
+
+    num_cpus = multiprocessing.cpu_count()
+    if cpu_pct > 0:
+        for _ in range(num_cpus):
+            t = threading.Thread(target=_cpu_worker, args=(stop, cpu_pct, duration), daemon=True)
+            t.start()
+            threads.append(t)
+
+    if ram_pct > 0:
+        t = threading.Thread(target=_ram_worker, args=(stop, ram_pct, duration), daemon=True)
+        t.start()
+        threads.append(t)
+
+    time.sleep(duration)
+    stop.set()
+    for t in threads:
+        t.join(timeout=5)
+
+    with _burn_lock:
+        _burn_active = False
+
+
+@app.route("/")
+def healthz():
+    return jsonify({"status": "ok"}), 200
+
+
+@app.route("/burn")
+def burn():
+    global _burn_active
+    with _burn_lock:
+        if _burn_active:
+            return jsonify({"status": "already burning"}), 409
+        _burn_active = True
+
+    t = threading.Thread(target=_run_burn, args=(CPU_PERCENT, RAM_PERCENT, DURATION), daemon=True)
+    t.start()
+
+    return jsonify({
+        "status": "burning",
+        "cpu_percent": CPU_PERCENT,
+        "ram_percent": RAM_PERCENT,
+        "duration_seconds": DURATION,
+    }), 202
+
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", 8080))
+    app.run(host="0.0.0.0", port=port)

--- a/containers/load-tester/docker-bake.hcl
+++ b/containers/load-tester/docker-bake.hcl
@@ -1,0 +1,35 @@
+DATE = formatdate( "YYYY.MM.DD", timestamp() )
+variable "GIT_SHA" {}
+variable "VERSION" {
+    default = "1.0.0"
+}
+
+target "default" {
+    context    = "."
+    dockerfile = "Dockerfile"
+    no-cache   = true
+    platforms  = ["linux/amd64", "linux/arm64"]
+
+    tags = [
+        "ghcr.io/mirceanton/load-tester:latest",
+        "ghcr.io/mirceanton/load-tester:sha-${GIT_SHA}",
+        "ghcr.io/mirceanton/load-tester:date-${DATE}",
+        "ghcr.io/mirceanton/load-tester:${VERSION}",
+        can(regex("^[0-9]+\\.[0-9]+\\.[0-9]+", VERSION)) ? "ghcr.io/mirceanton/load-tester:${regex("^([0-9]+\\.[0-9]+)", VERSION)[0]}" : "",
+        can(regex("^[0-9]+\\.[0-9]+\\.[0-9]+", VERSION)) ? "ghcr.io/mirceanton/load-tester:${regex("^([0-9]+)", VERSION)[0]}" : ""
+    ]
+
+    labels = {
+        "org.opencontainers.image.vendor"      = "Mircea-Pavel Anton"
+        "org.opencontainers.image.source"      = "https://github.com/mirceanton/container-images"
+        "org.opencontainers.image.created"     = "${DATE}"
+        "org.opencontainers.image.revision"    = "${GIT_SHA}"
+        "org.opencontainers.image.licenses"    = "MIT"
+
+        "org.opencontainers.image.title"       = "load-tester"
+        "org.opencontainers.image.authors"     = "Mircea-Pavel Anton"
+        "org.opencontainers.image.description" = "Minimal REST API for simulating CPU/RAM load — used to demo Kubernetes HPA autoscaling"
+        "org.opencontainers.image.url"         = "https://github.com/mirceanton/container-images"
+        "org.opencontainers.image.version"     = "${VERSION}"
+    }
+}

--- a/containers/load-tester/requirements.txt
+++ b/containers/load-tester/requirements.txt
@@ -1,0 +1,2 @@
+flask==3.1.1
+gunicorn==23.0.0


### PR DESCRIPTION
## Summary

- Adds a new `load-tester` container image built on `python:3.13-alpine` with Flask + gunicorn
- Exposes two HTTP routes: `GET /` (200 OK health check) and `GET /burn` (triggers background CPU/RAM stress)
- Load intensity and duration are configurable via environment variables (`CPU_PERCENT`, `RAM_PERCENT`, `BURN_DURATION`), making it easy to tune for HPA threshold demos

## Intended use

Deploy this image in a Kubernetes cluster, configure an HPA targeting CPU utilization, then hit `GET /burn` to drive load and watch pods scale out.

## Environment variables

| Variable | Default | Description |
|---|---|---|
| `CPU_PERCENT` | `80` | Target CPU load per core during burn |
| `RAM_PERCENT` | `0` | Percentage of total RAM to allocate |
| `BURN_DURATION` | `30` | Duration of the stress test in seconds |
| `PORT` | `8080` | HTTP listening port |

## Test plan

- [x] `docker build` succeeds for `linux/amd64` (verified locally)
- [x] `GET /` returns `{"status": "ok"}` with HTTP 200
- [x] `GET /burn` returns `202` and starts background load
- [x] Second `GET /burn` during active burn returns `409 {"status": "already burning"}`
- [x] After `BURN_DURATION` elapses, `GET /burn` accepts a new request again
- [x] `hadolint` passes with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)